### PR TITLE
Do not enable autodetect ok button when there is no server detected

### DIFF
--- a/src/dialogautodetect.cpp
+++ b/src/dialogautodetect.cpp
@@ -9,6 +9,7 @@ DialogAutoDetect::DialogAutoDetect(QWidget *parent) :
 {
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     ui->setupUi(this);
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
     udpSocket = new QUdpSocket(this);
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(timeout()));
@@ -59,6 +60,7 @@ void DialogAutoDetect::readPendingDatagrams()
             if (ui->list->count() == 1)
                 ui->list->setCurrentRow(0);
         }
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
     }
 }
 

--- a/src/dialogautodetect.h
+++ b/src/dialogautodetect.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QTimer>
 #include <QUdpSocket>
+#include <QPushButton>
 
 namespace Ui {
 class DialogAutoDetect;


### PR DESCRIPTION
In order to avoid segfault of installer.