### PR TITLE
Clear list when item rules changed even if rule is non existent.

### DIFF
--- a/src/formrules.cpp
+++ b/src/formrules.cpp
@@ -2188,12 +2188,13 @@ void FormRules::on_bt_rules_add_clicked()
 
 void FormRules::on_tree_rules_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *)
 {
+    //clear both lists
+    ui->tree_condition->clear_all();
+    ui->tree_action->clear_all();
+
     QTreeWidgetItemRule *itrule = dynamic_cast<QTreeWidgetItemRule *>(current);
     if (itrule)
     {
-        //clear both lists
-        ui->tree_condition->clear_all();
-        ui->tree_action->clear_all();
 
         //add new elements from selected rule
         Rule *rule = itrule->getRule();


### PR DESCRIPTION
This fix a bug when "Display associated rules" is clicked and there is no associated rules. Before that, the actions and conditions from the previous rules were displayed and lead to confusing display.