### PR TITLE
3Add Home Assistant MQTT discovery with climate entity support

### DIFF
--- a/calaos_installer.pro
+++ b/calaos_installer.pro
@@ -3,8 +3,13 @@ QT += core gui network widgets xml printsupport quick qml quickwidgets quickcont
 qtHaveModule(mqtt) {
     QT += mqtt
     DEFINES += QT_MQTT_AVAILABLE
-    SOURCES += src/DialogZigbee2mqtt.cpp
-    HEADERS += src/DialogZigbee2mqtt.h
+    SOURCES += src/DialogZigbee2mqtt.cpp \
+        src/DialogHomeAssistantMqtt.cpp \
+        src/HomeAssistantDiscovery.cpp
+    HEADERS += src/DialogZigbee2mqtt.h \
+        src/DialogHomeAssistantMqtt.h \
+        src/HomeAssistantDiscovery.h
+    FORMS += src/DialogHomeAssistantMqtt.ui
 }
 
 equals(QT_MAJOR_VERSION, 6) {

--- a/src/ConfigOptions.h
+++ b/src/ConfigOptions.h
@@ -41,6 +41,8 @@ public:
     void setMqttBrokerUser(QString s) { settings.setValue("calaos/mqtt_broker_user", s); }
     QString getMqttBrokerPass() { return settings.value("calaos/mqtt_broker_pass", "").toString(); }
     void setMqttBrokerPass(QString s) { settings.setValue("calaos/mqtt_broker_pass", s); }
+    QString getHADiscoveryPrefix() { return settings.value("calaos/ha_discovery_prefix", "homeassistant").toString(); }
+    void setHADiscoveryPrefix(QString s) { settings.setValue("calaos/ha_discovery_prefix", s); }
 
     void saveConfig() { settings.sync(); }
 

--- a/src/DialogHomeAssistantMqtt.cpp
+++ b/src/DialogHomeAssistantMqtt.cpp
@@ -1,0 +1,261 @@
+#include "DialogHomeAssistantMqtt.h"
+#include "ui_DialogHomeAssistantMqtt.h"
+#include "ConfigOptions.h"
+#include "ListeRoom.h"
+#include "Room.h"
+#include "IOBase.h"
+#include <QMessageBox>
+#include <QMqttSubscription>
+
+using namespace Calaos;
+
+DialogHomeAssistantMqtt::DialogHomeAssistantMqtt(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::DialogHomeAssistantMqtt)
+{
+    ui->setupUi(this);
+    ui->spinBoxPort->setMinimum(1);
+    ui->spinBoxPort->setMaximum(65535);
+
+    mqttClient = new QMqttClient(this);
+
+    connect(ui->lineEditHost, &QLineEdit::textChanged, mqttClient, &QMqttClient::setHostname);
+    connect(ui->spinBoxPort, QOverload<int>::of(&QSpinBox::valueChanged), this,
+            [this](int p) { mqttClient->setPort(static_cast<quint16>(p)); });
+    connect(ui->lineEditUsername, &QLineEdit::textChanged, mqttClient, &QMqttClient::setUsername);
+    connect(ui->lineEditPassword, &QLineEdit::textChanged, mqttClient, &QMqttClient::setPassword);
+    connect(mqttClient, &QMqttClient::disconnected, this, &DialogHomeAssistantMqtt::brokerDisconnected);
+    connect(mqttClient, &QMqttClient::stateChanged, this, &DialogHomeAssistantMqtt::stateChanged);
+
+    ui->spinBoxPort->setValue(ConfigOptions::Instance().getMqttBrokerPort());
+    ui->lineEditHost->setText(ConfigOptions::Instance().getMqttBrokerHost());
+    ui->lineEditUsername->setText(ConfigOptions::Instance().getMqttBrokerUser());
+    ui->lineEditPassword->setText(ConfigOptions::Instance().getMqttBrokerPass());
+    ui->lineEditPrefix->setText(ConfigOptions::Instance().getHADiscoveryPrefix());
+
+    mqttClient->setHostname(ui->lineEditHost->text());
+    mqttClient->setPort(static_cast<quint16>(ui->spinBoxPort->value()));
+    mqttClient->setUsername(ui->lineEditUsername->text());
+    mqttClient->setPassword(ui->lineEditPassword->text());
+
+    // Populate room combo from current project.
+    for (int i = 0; i < ListeRoom::Instance().size(); ++i) {
+        Room *r = ListeRoom::Instance().get_room(i);
+        ui->comboBoxRoom->addItem(QString::fromStdString(r->get_name()), QVariant::fromValue(reinterpret_cast<quintptr>(r)));
+    }
+
+    model.setHorizontalHeaderLabels(QStringList() << tr("Name") << tr("Component") << tr("Topic"));
+    ui->treeEntities->setModel(&model);
+
+    connect(&discovery, &HomeAssistantDiscovery::entityAddedOrUpdated,
+            this, &DialogHomeAssistantMqtt::onEntity);
+    connect(&discovery, &HomeAssistantDiscovery::entityRemoved,
+            this, &DialogHomeAssistantMqtt::onEntityRemoved);
+}
+
+DialogHomeAssistantMqtt::~DialogHomeAssistantMqtt()
+{
+    delete ui;
+}
+
+QString DialogHomeAssistantMqtt::currentPrefix() const
+{
+    QString p = ui->lineEditPrefix->text().trimmed();
+    if (p.isEmpty()) p = "homeassistant";
+    return p;
+}
+
+void DialogHomeAssistantMqtt::on_pushButtonConnect_clicked()
+{
+    if (mqttClient->state() == QMqttClient::Disconnected) {
+        ui->lineEditHost->setEnabled(false);
+        ui->spinBoxPort->setEnabled(false);
+        ui->lineEditUsername->setEnabled(false);
+        ui->lineEditPassword->setEnabled(false);
+        ui->lineEditPrefix->setEnabled(false);
+
+        spinner = new QAnimationLabel(":/img/loader.gif", this);
+        ui->verticalLayoutConnect->addWidget(spinner, 0, Qt::AlignCenter);
+        spinner->start();
+
+        ui->pushButtonConnect->setEnabled(false);
+        mqttClient->connectToHost();
+    } else {
+        mqttClient->disconnectFromHost();
+    }
+}
+
+void DialogHomeAssistantMqtt::subscribeDiscovery()
+{
+    QString topic = currentPrefix() + "/#";
+    auto sub = mqttClient->subscribe({topic});
+    if (!sub) {
+        QMessageBox::critical(this, tr("Error"), tr("Could not subscribe to %1").arg(topic));
+        return;
+    }
+    connect(sub, &QMqttSubscription::messageReceived, this, [this](QMqttMessage msg) {
+        QString t = msg.topic().name();
+        if (!HomeAssistantDiscovery::isDiscoveryTopic(t, currentPrefix()))
+            return;
+        discovery.handleMessage(t, msg.payload());
+    });
+    ui->labelStatus->setText(tr("Subscribed to %1 - waiting for retained discovery messages...").arg(topic));
+}
+
+void DialogHomeAssistantMqtt::stateChanged(QMqttClient::ClientState state)
+{
+    if (state == QMqttClient::Connected) {
+        ui->pushButtonConnect->setText(tr("Disconnect"));
+        ui->pushButtonConnect->setEnabled(true);
+        if (spinner) { spinner->stop(); delete spinner; }
+
+        ConfigOptions::Instance().setMqttBrokerHost(ui->lineEditHost->text());
+        ConfigOptions::Instance().setMqttBrokerPort(ui->spinBoxPort->value());
+        ConfigOptions::Instance().setMqttBrokerUser(ui->lineEditUsername->text());
+        ConfigOptions::Instance().setMqttBrokerPass(ui->lineEditPassword->text());
+        ConfigOptions::Instance().setHADiscoveryPrefix(currentPrefix());
+
+        subscribeDiscovery();
+    } else if (state == QMqttClient::Disconnected) {
+        ui->lineEditHost->setEnabled(true);
+        ui->spinBoxPort->setEnabled(true);
+        ui->lineEditUsername->setEnabled(true);
+        ui->lineEditPassword->setEnabled(true);
+        ui->lineEditPrefix->setEnabled(true);
+        ui->pushButtonConnect->setText(tr("Connect"));
+        ui->pushButtonConnect->setEnabled(true);
+        if (spinner) { spinner->stop(); delete spinner; }
+    }
+}
+
+void DialogHomeAssistantMqtt::brokerDisconnected()
+{
+    ui->labelStatus->setText(tr("Disconnected."));
+}
+
+void DialogHomeAssistantMqtt::onEntity(const HomeAssistantDiscovery::Entity &e)
+{
+    QStandardItem *devItem = deviceItems.value(e.deviceKey, nullptr);
+    if (!devItem) {
+        devItem = new QStandardItem(e.deviceName.isEmpty() ? e.deviceKey : e.deviceName);
+        QFont f = devItem->font(); f.setBold(true); devItem->setFont(f);
+        deviceItems.insert(e.deviceKey, devItem);
+        model.appendRow(devItem);
+        ui->treeEntities->setFirstColumnSpanned(model.rowCount() - 1, ui->treeEntities->rootIndex(), false);
+    }
+
+    QString name = e.name.isEmpty() ? e.objectId : e.name;
+    QString topic = e.payload.value("state_topic").toString();
+    if (topic.isEmpty()) topic = e.payload.value("command_topic").toString();
+
+    QStandardItem *existing = entityItems.value(e.uniqueId, nullptr);
+    if (existing) {
+        existing->setText(name);
+        existing->parent()->child(existing->row(), 1)->setText(e.component);
+        existing->parent()->child(existing->row(), 2)->setText(topic);
+    } else {
+        auto *nameItem = new QStandardItem(name);
+        nameItem->setData(e.uniqueId, Qt::UserRole + 1);
+        auto *compItem = new QStandardItem(e.component);
+        auto *topicItem = new QStandardItem(topic);
+        devItem->appendRow({nameItem, compItem, topicItem});
+        entityItems.insert(e.uniqueId, nameItem);
+    }
+}
+
+void DialogHomeAssistantMqtt::onEntityRemoved(const QString &uniqueId)
+{
+    QStandardItem *item = entityItems.take(uniqueId);
+    if (!item) return;
+    QStandardItem *parent = item->parent();
+    if (parent) parent->removeRow(item->row());
+}
+
+static bool ioWithUniqueIdExists(const QString &uniqueId)
+{
+    if (uniqueId.isEmpty()) return false;
+    auto check = [&](IOBase *io) {
+        // Stored ids may be suffixed "<uid>#<n>" when one entity yielded several IOs.
+        QString stored = QString::fromStdString(io->get_params()["ha_unique_id"]);
+        return stored == uniqueId || stored.section('#', 0, 0) == uniqueId;
+    };
+    auto &lr = ListeRoom::Instance();
+    for (int i = 0; i < lr.size(); ++i) {
+        Room *r = lr.get_room(i);
+        for (int j = 0; j < r->get_size_in(); ++j)
+            if (check(r->get_input(j))) return true;
+        for (int j = 0; j < r->get_size_out(); ++j)
+            if (check(r->get_output(j))) return true;
+    }
+    return false;
+}
+
+void DialogHomeAssistantMqtt::on_buttonBox_accepted()
+{
+    auto selection = ui->treeEntities->selectionModel()->selectedRows();
+    if (selection.isEmpty()) {
+        QMessageBox::warning(this, tr("Error"), tr("Please select at least one entity to import."));
+        return;
+    }
+
+    Room *targetRoom = reinterpret_cast<Room*>(static_cast<quintptr>(
+        ui->comboBoxRoom->currentData().toULongLong()));
+    if (!targetRoom) {
+        QMessageBox::warning(this, tr("Error"), tr("Please select a target room."));
+        return;
+    }
+
+    HomeAssistantDiscovery::BrokerCreds b;
+    b.host = ui->lineEditHost->text();
+    b.port = ui->spinBoxPort->value();
+    b.user = ui->lineEditUsername->text();
+    b.password = ui->lineEditPassword->text();
+
+    auto byDevice = discovery.entitiesByDevice();
+    QHash<QString, HomeAssistantDiscovery::Entity> byUniqueId;
+    for (const auto &list : byDevice)
+        for (const auto &e : list)
+            byUniqueId.insert(e.uniqueId, e);
+
+    importItems.clear();
+    warnings.clear();
+
+    for (const auto &idx : selection) {
+        // Skip device (root) rows.
+        if (!idx.parent().isValid()) continue;
+        auto *item = model.itemFromIndex(idx);
+        if (!item) continue;
+        QString uniqueId = item->data(Qt::UserRole + 1).toString();
+        auto eIt = byUniqueId.constFind(uniqueId);
+        if (eIt == byUniqueId.constEnd()) continue;
+
+        if (ioWithUniqueIdExists(uniqueId)) {
+            warnings << tr("Skipped (already imported): %1").arg(item->text());
+            continue;
+        }
+
+        QList<Params> ios;
+        QString reason;
+        if (!HomeAssistantDiscovery::toCalaosParams(eIt.value(), b, ios, reason)) {
+            warnings << tr("Skipped %1: %2").arg(item->text(), reason);
+            continue;
+        }
+        // One entity may yield several IOs (e.g. climate). Tag them all with the same
+        // ha_unique_id (suffixed per-IO when there are several) so re-import is detected.
+        int n = 0;
+        for (Params p : ios) {
+            QString uid = ios.size() > 1
+                ? QStringLiteral("%1#%2").arg(uniqueId).arg(n++)
+                : uniqueId;
+            p.Add("ha_unique_id", uid.toStdString());
+            importItems.append({p, targetRoom});
+        }
+    }
+
+    if (importItems.isEmpty() && !warnings.isEmpty()) {
+        QMessageBox::warning(this, tr("Nothing to import"), warnings.join('\n'));
+        return;
+    }
+
+    accept();
+}

--- a/src/DialogHomeAssistantMqtt.h
+++ b/src/DialogHomeAssistantMqtt.h
@@ -1,0 +1,63 @@
+#ifndef DIALOGHOMEASSISTANTMQTT_H
+#define DIALOGHOMEASSISTANTMQTT_H
+
+#include <QDialog>
+#include <QPointer>
+#include <QStandardItemModel>
+#include <QtMqtt/QMqttClient>
+#include "Params.h"
+#include "HomeAssistantDiscovery.h"
+#include "qanimationlabel.h"
+
+namespace Calaos { class Room; }
+
+namespace Ui {
+class DialogHomeAssistantMqtt;
+}
+
+class DialogHomeAssistantMqtt : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit DialogHomeAssistantMqtt(QWidget *parent = nullptr);
+    ~DialogHomeAssistantMqtt();
+
+    struct ImportItem {
+        Params params;
+        Calaos::Room *room;
+    };
+
+    // Items the user selected for import (after Accepted).
+    QList<ImportItem> getImportItems() const { return importItems; }
+
+    // Skipped duplicates / errors collected during accept().
+    QStringList getWarnings() const { return warnings; }
+
+private slots:
+    void on_pushButtonConnect_clicked();
+    void on_buttonBox_accepted();
+    void brokerDisconnected();
+    void stateChanged(QMqttClient::ClientState state);
+
+private:
+    Ui::DialogHomeAssistantMqtt *ui;
+    QPointer<QAnimationLabel> spinner;
+    QMqttClient *mqttClient = nullptr;
+
+    HomeAssistantDiscovery discovery;
+    QStandardItemModel model;
+    // Map deviceKey -> root QStandardItem
+    QHash<QString, QStandardItem*> deviceItems;
+    // Map uniqueId -> child QStandardItem
+    QHash<QString, QStandardItem*> entityItems;
+
+    QList<ImportItem> importItems;
+    QStringList warnings;
+
+    void onEntity(const HomeAssistantDiscovery::Entity &e);
+    void onEntityRemoved(const QString &uniqueId);
+    void subscribeDiscovery();
+    QString currentPrefix() const;
+};
+
+#endif // DIALOGHOMEASSISTANTMQTT_H

--- a/src/DialogHomeAssistantMqtt.ui
+++ b/src/DialogHomeAssistantMqtt.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DialogHomeAssistantMqtt</class>
+ <widget class="QDialog" name="DialogHomeAssistantMqtt">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>760</width>
+    <height>620</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Home Assistant MQTT discovery</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="groupBoxConnection">
+     <property name="title">
+      <string>Connection</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0"><widget class="QLabel" name="label"><property name="text"><string>Host:</string></property></widget></item>
+        <item row="0" column="1"><widget class="QLineEdit" name="lineEditHost"/></item>
+        <item row="1" column="0"><widget class="QLabel" name="label_2"><property name="text"><string>Port:</string></property></widget></item>
+        <item row="1" column="1"><widget class="QSpinBox" name="spinBoxPort"/></item>
+        <item row="2" column="0"><widget class="QLabel" name="label_3"><property name="text"><string>Username:</string></property></widget></item>
+        <item row="2" column="1"><widget class="QLineEdit" name="lineEditUsername"/></item>
+        <item row="3" column="0"><widget class="QLabel" name="label_4"><property name="text"><string>Password:</string></property></widget></item>
+        <item row="3" column="1"><widget class="QLineEdit" name="lineEditPassword"><property name="echoMode"><enum>QLineEdit::Password</enum></property></widget></item>
+        <item row="4" column="0"><widget class="QLabel" name="label_5"><property name="text"><string>Discovery prefix:</string></property></widget></item>
+        <item row="4" column="1"><widget class="QLineEdit" name="lineEditPrefix"/></item>
+        <item row="5" column="0"><widget class="QLabel" name="label_6"><property name="text"><string>Target room:</string></property></widget></item>
+        <item row="5" column="1"><widget class="QComboBox" name="comboBoxRoom"/></item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayoutConnect">
+        <item><widget class="QPushButton" name="pushButtonConnect"><property name="text"><string>Connect</string></property></widget></item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation"><enum>Qt::Vertical</enum></property>
+          <property name="sizeHint" stdset="0"><size><width>20</width><height>40</height></size></property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeView" name="treeEntities">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="editTriggers"><set>QAbstractItemView::NoEditTriggers</set></property>
+     <property name="alternatingRowColors"><bool>true</bool></property>
+     <property name="selectionMode"><enum>QAbstractItemView::ExtendedSelection</enum></property>
+     <property name="selectionBehavior"><enum>QAbstractItemView::SelectRows</enum></property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelStatus">
+     <property name="text"><string/></property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation"><enum>Qt::Horizontal</enum></property>
+     <property name="standardButtons"><set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set></property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DialogHomeAssistantMqtt</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel"><x>0</x><y>0</y></hint>
+    <hint type="destinationlabel"><x>0</x><y>0</y></hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/HomeAssistantDiscovery.cpp
+++ b/src/HomeAssistantDiscovery.cpp
@@ -1,0 +1,549 @@
+#include "HomeAssistantDiscovery.h"
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QRegularExpression>
+#include <QDebug>
+
+namespace {
+
+// Subset of HA's abbreviation table - the ones we actually map. Anything not
+// listed is kept verbatim so unknown keys still flow through.
+// Reference: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+const QHash<QString, QString> &abbrevMap()
+{
+    static const QHash<QString, QString> m = {
+        {"~", "topic_base"},
+        {"t", "topic"},
+        {"stat_t", "state_topic"},
+        {"cmd_t", "command_topic"},
+        {"avty", "availability"},
+        {"avty_t", "availability_topic"},
+        {"pl_on", "payload_on"},
+        {"pl_off", "payload_off"},
+        {"pl_open", "payload_open"},
+        {"pl_cls", "payload_close"},
+        {"pl_stop", "payload_stop"},
+        {"pl_avail", "payload_available"},
+        {"pl_not_avail", "payload_not_available"},
+        {"uniq_id", "unique_id"},
+        {"obj_id", "object_id"},
+        {"dev_cla", "device_class"},
+        {"stat_cla", "state_class"},
+        {"unit_of_meas", "unit_of_measurement"},
+        {"val_tpl", "value_template"},
+        {"ic", "icon"},
+        {"qos", "qos"},
+        {"ret", "retain"},
+        {"frc_upd", "force_update"},
+        {"exp_aft", "expire_after"},
+        {"dev", "device"},
+        {"o", "origin"},
+        {"cmps", "components"},
+        {"ids", "identifiers"},
+        {"cns", "connections"},
+        {"mf", "manufacturer"},
+        {"mdl", "model"},
+        {"sw", "sw_version"},
+        {"hw", "hw_version"},
+        {"name", "name"},
+        {"bri_cmd_t", "brightness_command_topic"},
+        {"bri_stat_t", "brightness_state_topic"},
+        {"bri_val_tpl", "brightness_value_template"},
+        {"bri_scl", "brightness_scale"},
+        {"rgb_cmd_t", "rgb_command_topic"},
+        {"rgb_stat_t", "rgb_state_topic"},
+        {"xy_cmd_t", "xy_command_topic"},
+        {"xy_stat_t", "xy_state_topic"},
+        {"hs_cmd_t", "hs_command_topic"},
+        {"pos_t", "position_topic"},
+        {"set_pos_t", "set_position_topic"},
+        {"min", "min"},
+        {"max", "max"},
+        {"schema", "schema"},
+        // climate
+        {"mode_cmd_t", "mode_command_topic"},
+        {"mode_stat_t", "mode_state_topic"},
+        {"mode_stat_tpl", "mode_state_template"},
+        {"modes", "modes"},
+        {"curr_temp_t", "current_temperature_topic"},
+        {"curr_temp_tpl", "current_temperature_template"},
+        {"temp_cmd_t", "temperature_command_topic"},
+        {"temp_stat_t", "temperature_state_topic"},
+        {"temp_stat_tpl", "temperature_state_template"},
+        {"min_temp", "min_temp"},
+        {"max_temp", "max_temp"},
+        {"temp_step", "temp_step"},
+        {"temp_unit", "temperature_unit"},
+        {"fan_mode_cmd_t", "fan_mode_command_topic"},
+        {"fan_mode_stat_t", "fan_mode_state_topic"},
+        {"fan_mode_stat_tpl", "fan_mode_state_template"},
+        {"fan_modes", "fan_modes"},
+        {"swing_mode_cmd_t", "swing_mode_command_topic"},
+        {"swing_mode_stat_t", "swing_mode_state_topic"},
+        {"act_t", "action_topic"},
+        {"act_tpl", "action_template"},
+        {"sug_dsp_prc", "suggested_display_precision"},
+        {"ent_cat", "entity_category"},
+    };
+    return m;
+}
+
+QString expandAbbrev(const QString &key)
+{
+    auto it = abbrevMap().constFind(key);
+    return it == abbrevMap().constEnd() ? key : it.value();
+}
+
+// Replace any "~" prefix in topic-like fields with the payload's `topic_base`.
+QString resolveTopic(const QString &raw, const QString &base)
+{
+    if (raw.startsWith('~'))
+        return base + raw.mid(1);
+    if (raw.endsWith('~'))
+        return raw.left(raw.size() - 1) + base;
+    return raw;
+}
+
+QJsonValue expandValue(const QJsonValue &v)
+{
+    if (v.isObject())
+        return HomeAssistantDiscovery::expandAbbreviations(v.toObject());
+    if (v.isArray()) {
+        QJsonArray out;
+        for (const auto &item : v.toArray())
+            out.append(expandValue(item));
+        return out;
+    }
+    return v;
+}
+
+QString firstNonEmpty(std::initializer_list<QString> vals)
+{
+    for (const auto &v : vals)
+        if (!v.isEmpty())
+            return v;
+    return QString();
+}
+
+} // namespace
+
+HomeAssistantDiscovery::HomeAssistantDiscovery(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QJsonObject HomeAssistantDiscovery::expandAbbreviations(const QJsonObject &in)
+{
+    QJsonObject out;
+    for (auto it = in.begin(); it != in.end(); ++it)
+        out.insert(expandAbbrev(it.key()), expandValue(it.value()));
+    return out;
+}
+
+bool HomeAssistantDiscovery::isDiscoveryTopic(const QString &topic, const QString &prefix)
+{
+    if (!topic.startsWith(prefix + "/"))
+        return false;
+    if (!topic.endsWith("/config"))
+        return false;
+    // Minimum: prefix / component / object_id / config => 4 segments
+    return topic.count('/') >= 3;
+}
+
+QString HomeAssistantDiscovery::jsonPointerFromTemplate(const QString &valueTemplate)
+{
+    // Best-effort: handle "{{ value_json.foo }}", "{{ value_json.foo.bar }}",
+    // "{{ value_json['foo'] }}". Anything more complex -> empty (use raw payload).
+    static const QRegularExpression rx(
+        R"(\{\{\s*value_json((?:\.[A-Za-z_][A-Za-z0-9_]*|\[['"][^'"]+['"]\])+)\s*\}\})");
+    auto m = rx.match(valueTemplate);
+    if (!m.hasMatch())
+        return QString();
+
+    QString accessors = m.captured(1);
+    static const QRegularExpression part(R"(\.([A-Za-z_][A-Za-z0-9_]*)|\[['"]([^'"]+)['"]\])");
+    auto it = part.globalMatch(accessors);
+    QStringList parts;
+    while (it.hasNext()) {
+        auto pm = it.next();
+        parts << (pm.captured(1).isEmpty() ? pm.captured(2) : pm.captured(1));
+    }
+    return parts.join('/');
+}
+
+bool HomeAssistantDiscovery::handleMessage(const QString &topic, const QByteArray &payload)
+{
+    // Parse topic: <prefix>/<component>/[<node>/]<object_id>/config
+    QStringList parts = topic.split('/');
+    if (parts.size() < 4 || parts.last() != "config")
+        return false;
+    QString component = parts.at(1);
+    QString objectId = parts.at(parts.size() - 2);
+
+    // Empty payload = removal of a retained discovery entry.
+    if (payload.trimmed().isEmpty()) {
+        QString removedKey;
+        for (auto it = entities.begin(); it != entities.end(); ++it) {
+            if (it.value().topic == topic) { removedKey = it.key(); break; }
+        }
+        if (removedKey.isEmpty())
+            return false;
+        entities.remove(removedKey);
+        emit entityRemoved(removedKey);
+        return true;
+    }
+
+    QJsonParseError err;
+    QJsonDocument jdoc = QJsonDocument::fromJson(payload, &err);
+    if (err.error != QJsonParseError::NoError || !jdoc.isObject()) {
+        qWarning() << "HA discovery: bad JSON on" << topic << err.errorString();
+        return false;
+    }
+    QJsonObject raw = expandAbbreviations(jdoc.object());
+
+    // Resolve "~" topic_base shortcuts.
+    QString base = raw.value("topic_base").toString();
+    if (!base.isEmpty()) {
+        QJsonObject expanded = raw;
+        for (auto it = raw.begin(); it != raw.end(); ++it) {
+            if (it.value().isString() && it.key().endsWith("_topic"))
+                expanded.insert(it.key(), resolveTopic(it.value().toString(), base));
+        }
+        raw = expanded;
+    }
+
+    Entity e;
+    e.topic = topic;
+    e.component = component;
+    e.objectId = objectId;
+    e.payload = raw;
+    e.uniqueId = firstNonEmpty({raw.value("unique_id").toString(), objectId});
+    e.name = raw.value("name").toString();
+
+    QJsonObject dev = raw.value("device").toObject();
+    QString devId;
+    auto ids = dev.value("identifiers");
+    if (ids.isArray() && !ids.toArray().isEmpty())
+        devId = ids.toArray().first().toString();
+    else if (ids.isString())
+        devId = ids.toString();
+    e.deviceName = dev.value("name").toString();
+    e.deviceKey = firstNonEmpty({devId, e.deviceName, e.uniqueId});
+    if (e.deviceName.isEmpty())
+        e.deviceName = e.deviceKey;
+
+    entities.insert(e.uniqueId, e);
+    emit entityAddedOrUpdated(e);
+    return true;
+}
+
+void HomeAssistantDiscovery::clear()
+{
+    entities.clear();
+}
+
+QHash<QString, QList<HomeAssistantDiscovery::Entity>> HomeAssistantDiscovery::entitiesByDevice() const
+{
+    QHash<QString, QList<Entity>> out;
+    for (const auto &e : entities)
+        out[e.deviceKey].append(e);
+    return out;
+}
+
+bool HomeAssistantDiscovery::toCalaosParams(const Entity &e, const BrokerCreds &b,
+                                            QList<Params> &outList, QString &reason)
+{
+    const QJsonObject &p = e.payload;
+    const QString comp = e.component;
+
+    // Working Params for the single-IO components below. Climate ignores it and
+    // appends its own Params directly to outList.
+    Params out;
+
+    auto addBroker = [&](Params &io) {
+        io.Add("host", b.host.toStdString());
+        io.Add("port", QString::number(b.port).toStdString());
+        io.Add("user", b.user.toStdString());
+        io.Add("password", b.password.toStdString());
+    };
+
+    auto displayName = [&]() {
+        QString n = e.name;
+        if (n.isEmpty()) n = e.objectId;
+        if (!e.deviceName.isEmpty() && e.deviceName != n)
+            return QStringLiteral("%1 - %2").arg(e.deviceName, n);
+        return n;
+    };
+
+    QString stateTopic = p.value("state_topic").toString();
+    QString cmdTopic = p.value("command_topic").toString();
+    QString valTpl = p.value("value_template").toString();
+    QString path = jsonPointerFromTemplate(valTpl);
+    QString payloadOn = p.value("payload_on").toString("ON");
+    QString payloadOff = p.value("payload_off").toString("OFF");
+
+    if (comp == "binary_sensor")
+    {
+        out.Add("type", "MqttInputSwitch");
+        out.Add("io_type", "input");
+        out.Add("name", displayName().toStdString());
+        addBroker(out);
+        out.Add("topic_sub", stateTopic.toStdString());
+        if (!path.isEmpty()) out.Add("path", path.toStdString());
+        out.Add("on_value", payloadOn.toStdString());
+        out.Add("off_value", payloadOff.toStdString());
+        outList.append(out);
+        return true;
+    }
+    if (comp == "switch")
+    {
+        out.Add("type", "MqttOutputLight");
+        out.Add("io_type", "output");
+        out.Add("name", displayName().toStdString());
+        addBroker(out);
+        if (!stateTopic.isEmpty()) out.Add("topic_sub", stateTopic.toStdString());
+        out.Add("topic_pub", cmdTopic.toStdString());
+        if (!path.isEmpty()) out.Add("path", path.toStdString());
+        out.Add("on_value", payloadOn.toStdString());
+        out.Add("off_value", payloadOff.toStdString());
+        out.Add("data", "__##VALUE##__");
+        outList.append(out);
+        return true;
+    }
+    if (comp == "sensor")
+    {
+        out.Add("io_type", "input");
+        out.Add("name", displayName().toStdString());
+        addBroker(out);
+        out.Add("topic_sub", stateTopic.toStdString());
+        if (!path.isEmpty()) out.Add("path", path.toStdString());
+
+        QString unit = p.value("unit_of_measurement").toString();
+        QString devClass = p.value("device_class").toString();
+
+        if (devClass == "temperature") {
+            out.Add("type", "MqttInputTemp");
+        } else if (!unit.isEmpty() || !devClass.isEmpty()) {
+            out.Add("type", "MqttInputAnalog");
+            if (!unit.isEmpty()) out.Add("unit", unit.toStdString());
+            if (devClass == "humidity")          out.Add("io_style", "humidity");
+            else if (devClass == "pressure")     out.Add("io_style", "pressure");
+            else if (devClass == "voltage")      out.Add("io_style", "voltage");
+            else if (devClass == "current")      out.Add("io_style", "current");
+            else if (devClass == "power" || devClass == "energy")
+                                                  out.Add("io_style", "watt");
+            else if (devClass == "illuminance")  out.Add("io_style", "luminosity");
+        } else {
+            out.Add("type", "MqttInputString");
+        }
+        outList.append(out);
+        return true;
+    }
+    if (comp == "cover")
+    {
+        out.Add("type", "MqttOutputShutter");
+        out.Add("io_type", "output");
+        out.Add("name", displayName().toStdString());
+        addBroker(out);
+        if (!stateTopic.isEmpty()) out.Add("topic_sub", stateTopic.toStdString());
+        out.Add("topic_pub", cmdTopic.toStdString());
+        out.Add("on_value", p.value("payload_open").toString("OPEN").toStdString());
+        out.Add("off_value", p.value("payload_close").toString("CLOSE").toStdString());
+        out.Add("stop_value", p.value("payload_stop").toString("STOP").toStdString());
+        out.Add("data", "__##VALUE##__");
+        outList.append(out);
+        return true;
+    }
+    if (comp == "light")
+    {
+        out.Add("io_type", "output");
+        out.Add("name", displayName().toStdString());
+        addBroker(out);
+        if (!stateTopic.isEmpty()) out.Add("topic_sub", stateTopic.toStdString());
+        if (!cmdTopic.isEmpty())   out.Add("topic_pub", cmdTopic.toStdString());
+
+        bool hasRgb = p.contains("rgb_command_topic") || p.contains("xy_command_topic") ||
+                      p.contains("hs_command_topic");
+        bool hasBri = p.contains("brightness_command_topic") || p.value("brightness").toBool();
+        QString schema = p.value("schema").toString("default");
+
+        if (schema == "json") {
+            if (hasRgb) {
+                out.Add("type", "MqttOutputLightRGB");
+                out.Add("data", R"({"state":"__##VALUE##__","brightness":__##VALUE_BRIGHTNESS##__,"color":{"r":__##VALUE_R##__,"g":__##VALUE_G##__,"b":__##VALUE_B##__}})");
+                out.Add("path", "state");
+                out.Add("path_brightness", "brightness");
+                out.Add("path_x", "color/r");
+                out.Add("path_y", "color/g");
+            } else if (hasBri) {
+                out.Add("type", "MqttOutputLightDimmer");
+                out.Add("data", R"({"state":"ON","brightness":__##VALUE##__})");
+                out.Add("path", "brightness");
+            } else {
+                out.Add("type", "MqttOutputLight");
+                out.Add("on_value", "ON");
+                out.Add("off_value", "OFF");
+                out.Add("data", R"({"state":"__##VALUE##__"})");
+                out.Add("path", "state");
+            }
+        } else if (hasRgb) {
+            out.Add("type", "MqttOutputLightRGB");
+            out.Add("data", "__##VALUE_R##__,__##VALUE_G##__,__##VALUE_B##__");
+        } else if (hasBri) {
+            out.Add("type", "MqttOutputLightDimmer");
+            // separate brightness topic - override topic_pub to brightness command topic
+            QString briCmd = p.value("brightness_command_topic").toString();
+            if (!briCmd.isEmpty()) {
+                out.Add("topic_pub", briCmd.toStdString());
+                QString briState = p.value("brightness_state_topic").toString();
+                if (!briState.isEmpty()) out.Add("topic_sub", briState.toStdString());
+            }
+            out.Add("data", "__##VALUE##__");
+        } else {
+            out.Add("type", "MqttOutputLight");
+            out.Add("on_value", payloadOn.toStdString());
+            out.Add("off_value", payloadOff.toStdString());
+            out.Add("data", "__##VALUE##__");
+        }
+        outList.append(out);
+        return true;
+    }
+    if (comp == "number")
+    {
+        out.Add("type", "MqttOutputAnalog");
+        out.Add("io_type", "output");
+        out.Add("name", displayName().toStdString());
+        addBroker(out);
+        if (!stateTopic.isEmpty()) out.Add("topic_sub", stateTopic.toStdString());
+        out.Add("topic_pub", cmdTopic.toStdString());
+        QString unit = p.value("unit_of_measurement").toString();
+        if (!unit.isEmpty()) out.Add("unit", unit.toStdString());
+        out.Add("data", "__##VALUE##__");
+        outList.append(out);
+        return true;
+    }
+    if (comp == "climate")
+    {
+        // One HA/ESPHome climate entity exposes several independent topics. There is
+        // no native Calaos "thermostat" IO, so we split it into multiple IOs.
+        const QString base = displayName();
+
+        QString currTempTopic = p.value("current_temperature_topic").toString();
+        QString tempCmdTopic  = p.value("temperature_command_topic").toString();
+        QString tempStatTopic = p.value("temperature_state_topic").toString();
+        QString modeCmdTopic  = p.value("mode_command_topic").toString();
+        QString modeStatTopic = p.value("mode_state_topic").toString();
+        QString fanStatTopic  = p.value("fan_mode_state_topic").toString();
+        QString actionTopic   = p.value("action_topic").toString();
+
+        auto pathFromTpl = [](const QJsonObject &obj, const QString &key) {
+            return jsonPointerFromTemplate(obj.value(key).toString());
+        };
+
+        // Current temperature (read-only).
+        if (!currTempTopic.isEmpty()) {
+            Params io;
+            io.Add("type", "MqttInputTemp");
+            io.Add("io_type", "input");
+            io.Add("name", QStringLiteral("%1 - Current temperature").arg(base).toStdString());
+            addBroker(io);
+            io.Add("topic_sub", currTempTopic.toStdString());
+            QString tpl = pathFromTpl(p, "current_temperature_template");
+            if (!tpl.isEmpty()) io.Add("path", tpl.toStdString());
+            outList.append(io);
+        }
+
+        // Target temperature setpoint (read/write).
+        if (!tempCmdTopic.isEmpty()) {
+            Params io;
+            io.Add("type", "MqttOutputAnalog");
+            io.Add("io_type", "output");
+            io.Add("name", QStringLiteral("%1 - Target temperature").arg(base).toStdString());
+            addBroker(io);
+            io.Add("topic_pub", tempCmdTopic.toStdString());
+            if (!tempStatTopic.isEmpty()) io.Add("topic_sub", tempStatTopic.toStdString());
+            QString tpl = pathFromTpl(p, "temperature_state_template");
+            if (!tpl.isEmpty()) io.Add("path", tpl.toStdString());
+            io.Add("io_style", "temperature");
+            io.Add("unit", p.value("temperature_unit").toString("C") == "F" ? "°F" : "°C");
+            if (p.contains("min_temp")) io.Add("min", QString::number(p.value("min_temp").toDouble()).toStdString());
+            if (p.contains("max_temp")) io.Add("max", QString::number(p.value("max_temp").toDouble()).toStdString());
+            if (p.contains("temp_step")) io.Add("step", QString::number(p.value("temp_step").toDouble()).toStdString());
+            io.Add("data", "__##VALUE##__");
+            outList.append(io);
+        }
+
+        // Mode on/off control. No native enum output: map ON->first cooling/heating
+        //    mode, OFF->"off". User can tweak on_value afterwards.
+        if (!modeCmdTopic.isEmpty()) {
+            QString onMode = "cool";
+            auto modes = p.value("modes").toArray();
+            for (const auto &m : modes) {
+                QString s = m.toString();
+                if (s != "off" && s != "auto") { onMode = s; break; }
+            }
+            Params io;
+            io.Add("type", "MqttOutputLight");
+            io.Add("io_type", "output");
+            io.Add("name", QStringLiteral("%1 - Mode").arg(base).toStdString());
+            addBroker(io);
+            io.Add("topic_pub", modeCmdTopic.toStdString());
+            if (!modeStatTopic.isEmpty()) io.Add("topic_sub", modeStatTopic.toStdString());
+            QString tpl = pathFromTpl(p, "mode_state_template");
+            if (!tpl.isEmpty()) io.Add("path", tpl.toStdString());
+            io.Add("on_value", onMode.toStdString());
+            io.Add("off_value", "off");
+            io.Add("data", "__##VALUE##__");
+            outList.append(io);
+        }
+
+        // Mode readback (read-only string) when there's a state topic, useful to see
+        //    the real mode even when controlled as on/off above.
+        if (!modeStatTopic.isEmpty()) {
+            Params io;
+            io.Add("type", "MqttInputString");
+            io.Add("io_type", "input");
+            io.Add("name", QStringLiteral("%1 - Mode (state)").arg(base).toStdString());
+            addBroker(io);
+            io.Add("topic_sub", modeStatTopic.toStdString());
+            QString tpl = pathFromTpl(p, "mode_state_template");
+            if (!tpl.isEmpty()) io.Add("path", tpl.toStdString());
+            outList.append(io);
+        }
+
+        // Fan mode (read-only string).
+        if (!fanStatTopic.isEmpty()) {
+            Params io;
+            io.Add("type", "MqttInputString");
+            io.Add("io_type", "input");
+            io.Add("name", QStringLiteral("%1 - Fan mode").arg(base).toStdString());
+            addBroker(io);
+            io.Add("topic_sub", fanStatTopic.toStdString());
+            QString tpl = pathFromTpl(p, "fan_mode_state_template");
+            if (!tpl.isEmpty()) io.Add("path", tpl.toStdString());
+            outList.append(io);
+        }
+
+        // Action (read-only string: heating/cooling/idle/fan...).
+        if (!actionTopic.isEmpty()) {
+            Params io;
+            io.Add("type", "MqttInputString");
+            io.Add("io_type", "input");
+            io.Add("name", QStringLiteral("%1 - Action").arg(base).toStdString());
+            addBroker(io);
+            io.Add("topic_sub", actionTopic.toStdString());
+            QString tpl = pathFromTpl(p, "action_template");
+            if (!tpl.isEmpty()) io.Add("path", tpl.toStdString());
+            outList.append(io);
+        }
+
+        if (outList.isEmpty()) {
+            reason = QObject::tr("Climate entity has no usable topics");
+            return false;
+        }
+        return true;
+    }
+
+    reason = QObject::tr("Unsupported component: %1").arg(comp);
+    return false;
+}

--- a/src/HomeAssistantDiscovery.h
+++ b/src/HomeAssistantDiscovery.h
@@ -1,0 +1,67 @@
+#ifndef HOMEASSISTANTDISCOVERY_H
+#define HOMEASSISTANTDISCOVERY_H
+
+#include <QObject>
+#include <QHash>
+#include <QList>
+#include <QJsonObject>
+#include <QString>
+#include "Params.h"
+
+// Parses Home Assistant MQTT discovery payloads and converts them to Calaos IO Params.
+// See https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+class HomeAssistantDiscovery : public QObject
+{
+    Q_OBJECT
+public:
+    struct Entity {
+        QString topic;          // full discovery topic (.../config)
+        QString component;      // sensor, binary_sensor, switch, light, cover, number...
+        QString objectId;       // last path segment before /config
+        QString uniqueId;       // payload.unique_id (or objectId fallback)
+        QString name;           // payload.name (resolved)
+        QString deviceKey;      // device.identifiers[0] or device.name
+        QString deviceName;     // device.name (resolved)
+        QJsonObject payload;    // fully expanded payload (abbreviations -> long form)
+    };
+
+    struct BrokerCreds {
+        QString host;
+        int port = 1883;
+        QString user;
+        QString password;
+    };
+
+    explicit HomeAssistantDiscovery(QObject *parent = nullptr);
+
+    // Returns true if topic looks like "<prefix>/<component>/[<node>/]<obj>/config".
+    static bool isDiscoveryTopic(const QString &topic, const QString &prefix);
+
+    // Add or remove an entity based on a discovery message.
+    // Empty payload on a discovery topic removes the entity. Returns true if registry changed.
+    bool handleMessage(const QString &topic, const QByteArray &payload);
+
+    void clear();
+
+    // Iterate currently-known entities grouped by deviceKey.
+    QHash<QString, QList<Entity>> entitiesByDevice() const;
+
+    // Convert one discovered entity into one or more Params objects suitable for
+    // ListeRoom::createInput/Output. Most components yield a single IO; "climate"
+    // is split into several (current temp, setpoint, mode, fan mode, action...).
+    // Returns true on success and appends to `out`. Sets `reason` when unsupported.
+    static bool toCalaosParams(const Entity &e, const BrokerCreds &b, QList<Params> &out, QString &reason);
+
+    // Expose for unit tests.
+    static QJsonObject expandAbbreviations(const QJsonObject &in);
+    static QString jsonPointerFromTemplate(const QString &valueTemplate);
+
+signals:
+    void entityAddedOrUpdated(const HomeAssistantDiscovery::Entity &e);
+    void entityRemoved(const QString &uniqueId);
+
+private:
+    QHash<QString, Entity> entities; // keyed by uniqueId
+};
+
+#endif // HOMEASSISTANTDISCOVERY_H

--- a/src/formrules.cpp
+++ b/src/formrules.cpp
@@ -13,6 +13,7 @@
 
 #ifdef QT_MQTT_AVAILABLE
 #include "DialogZigbee2mqtt.h"
+#include "DialogHomeAssistantMqtt.h"
 #endif
 
 FormRules::FormRules(QWidget *parent) :
@@ -569,6 +570,46 @@ FormRules::FormRules(QWidget *parent) :
             auto p = d.getIOParam();
             addCalaosIO(p);
         }
+    });
+
+    action = add_menu->addAction(tr("Home Assistant MQTT discovery"));
+    action->setIcon(QIcon(":/img/mqtt.png"));
+    connect(action, &QAction::triggered, this, [=]()
+    {
+        if (ListeRoom::Instance().size() <= 0)
+        {
+            QMessageBox::warning(this, tr("Calaos Installer"), tr("You need to add one room at least!"));
+            return;
+        }
+
+        DialogHomeAssistantMqtt d(this);
+        if (d.exec() != QDialog::Accepted)
+            return;
+
+        for (const auto &item : d.getImportItems())
+        {
+            Params p = item.params;
+            p.Add("id", ListeRoom::get_new_id("io_"));
+            IOBase *io = nullptr;
+            if (p["io_type"] == "input")
+            {
+                io = ListeRoom::Instance().createInput(p, item.room);
+                addItemInput(io, item.room, true);
+            }
+            else
+            {
+                io = ListeRoom::Instance().createOutput(p, item.room);
+                addItemOutput(io, item.room, true);
+            }
+        }
+        setProjectModified(true);
+
+        auto warnings = d.getWarnings();
+        if (!warnings.isEmpty())
+            QMessageBox::information(this, tr("Import complete"),
+                tr("Imported %1 entit(y/ies).\n\nNotes:\n%2")
+                    .arg(d.getImportItems().size())
+                    .arg(warnings.join('\n')));
     });
 #endif
 


### PR DESCRIPTION
Discover Home Assistant / ESPHome MQTT entities and import them as Calaos IOs. Supports binary_sensor, sensor, switch, cover, light and number.

Climate entities have no native Calaos thermostat IO, so they are split into several IOs: current temperature (MqttInputTemp), target temperature (MqttOutputAnalog), mode on/off control (MqttOutputLight) plus read-only mode/fan/action state (MqttInputString). toCalaosParams now returns a list of Params so one entity can yield multiple IOs.